### PR TITLE
Add a workaround for inconsistent LinkType::RAW values

### DIFF
--- a/src/internal/block.rs
+++ b/src/internal/block.rs
@@ -2,7 +2,6 @@ use byteorder::ByteOrder;
 use error::*;
 use internal::*;
 use link_type::*;
-use num_traits::FromPrimitive;
 
 pub struct FramedBlock<'a> {
     pub len: usize,
@@ -157,7 +156,7 @@ impl<'a> FromBytes<'a> for InterfaceDescription {
     fn parse<B: ByteOrder>(buf: &'a [u8]) -> Result<InterfaceDescription> {
         let lt = B::read_u16(&buf[0..2]);
         Ok(InterfaceDescription {
-            link_type: LinkType::from_u16(lt).ok_or(Error::UnknownLinkType(lt))?,
+            link_type: LinkType::from_u16_with_hacks(lt).ok_or(Error::UnknownLinkType(lt))?,
             snap_len: B::read_u32(&buf[4..8]),
             options: Vec::from(&buf[8..]),
         })

--- a/src/link_type.rs
+++ b/src/link_type.rs
@@ -1,3 +1,5 @@
+use num_traits::FromPrimitive;
+
 #[allow(non_camel_case_types)]
 #[derive(Debug, Clone, PartialEq, FromPrimitive)]
 #[repr(u16)]
@@ -146,4 +148,19 @@ pub enum LinkType {
     IBM_SP = 145,
     /// Reserved for IBM SP switch and IBM Next Federation switch.
     IBM_SN = 146,
+}
+
+impl LinkType {
+    /// Decode LinkType from u16
+    ///
+    /// LINKTYPE_RAW is defined as 101 in the registry but for some reason libpcap uses DLT_RAW
+    /// defined as 14 on OpenBSD and as 12 for other platforms for the link type. So in order to
+    /// reliably decode link types we need to remap those numbers as LinkType::RAW here.
+    pub fn from_u16_with_hacks(i: u16) -> Option<Self> {
+        Self::from_u16(i).or_else(|| match i {
+            12 => Some(LinkType::RAW),
+            14 => Some(LinkType::RAW),
+            _ => None,
+        })
+    }
 }


### PR DESCRIPTION
This issue was caught in the test suite. The problem is that libpcap (and other software too?) uses `DLT_RAW` as the link type value for RAW packets but it doesn't match the LINKTYPE_RAW value defined in https://www.tcpdump.org/linktypes.html, which is 101.

Specifically libpcap uses
* DLT_RAW = 14 on OpenBSD
* DLT_RAW = 12 on other platforms

This PR works around the incompatibility in `LinkType::from_u16_with_hacks`. Now all tests pass.