### PR TITLE
Parse timestamps properly

### DIFF
--- a/src/internal/block_reader.rs
+++ b/src/internal/block_reader.rs
@@ -58,13 +58,6 @@ fn peek_for_shb(buf: &[u8]) -> Result<Option<Endianness>> {
         return Ok(None);
     }
     require_bytes(buf, 12)?;
-    let mut magic = [0; 4];
-    magic.copy_from_slice(&buf[8..12]);
-    if magic == [0x1A, 0x2B, 0x3C, 0x4D] {
-        Ok(Some(Endianness::Big))
-    } else if magic == [0x4D, 0x3C, 0x2B, 0x1A] {
-        Ok(Some(Endianness::Little))
-    } else {
-        Err(Error::DidntUnderstandMagicNumber(magic))
-    }
+    let endianness = Endianness::parse_from_magic(&buf[8..12])?;
+    Ok(Some(endianness))
 }

--- a/src/internal/section.rs
+++ b/src/internal/section.rs
@@ -1,17 +1,24 @@
+use byteorder::{BigEndian, LittleEndian};
 use internal::*;
 use packet::*;
 use std::u32;
 
 pub struct Section {
+    /// Endianness used in the current section. Each section can use a different endianness.
+    pub endianness: Endianness,
     pub interfaces: Vec<InterfaceDescription>,
     pub resolved_names: Vec<NameResolution>,
+    /// Timestamp resolution for each interface in the current section.
+    pub timestamp_options: Vec<TimestampOptions>,
 }
 
 impl Section {
     pub fn new() -> Section {
         Section {
+            endianness: Endianness::Little, // arbitrary default
             interfaces: Vec::new(),
             resolved_names: Vec::new(),
+            timestamp_options: Vec::new(),
         }
     }
 
@@ -19,8 +26,10 @@ impl Section {
         match block {
             Block::SectionHeader(x) => {
                 info!("Starting a new section: {:?}", x);
+                self.endianness = x.endianness;
                 self.interfaces.clear();
                 self.resolved_names.clear();
+                self.timestamp_options.clear();
                 None
             }
             Block::InterfaceDescription(x) => {
@@ -31,13 +40,28 @@ impl Section {
                           our buffer."
                     );
                 }
+                match self.endianness {
+                    Endianness::Big => self
+                        .timestamp_options
+                        .push(x.timestamp_options::<BigEndian>()),
+                    Endianness::Little => self
+                        .timestamp_options
+                        .push(x.timestamp_options::<LittleEndian>()),
+                }
+                info!("Set the timestamp options to {:?}", self.timestamp_options);
                 self.interfaces.push(x);
                 None
             }
             Block::EnhancedPacket(x) => {
                 debug!("Got a packet: {:?}", x);
-                let interface = self.lookup_interface(x.interface_id);
-                Some(Packet::new_enhanced(x.timestamp, interface, x.packet_data))
+                let interface = self.lookup_interface(&x.interface_id);
+                let timestamp_options = self.lookup_timestamp_options(&x.interface_id);
+                Some(Packet::new_enhanced(
+                    x.timestamp,
+                    timestamp_options,
+                    interface,
+                    x.packet_data,
+                ))
             }
             Block::SimplePacket(x) => {
                 debug!("Got a packet: {:?}", x);
@@ -45,8 +69,14 @@ impl Section {
             }
             Block::ObsoletePacket(x) => {
                 debug!("Got a packet: {:?}", x);
-                let interface = self.lookup_interface(x.interface_id);
-                Some(Packet::new_enhanced(x.timestamp, interface, x.packet_data))
+                let interface = self.lookup_interface(&x.interface_id);
+                let timestamp_options = self.lookup_timestamp_options(&x.interface_id);
+                Some(Packet::new_enhanced(
+                    x.timestamp,
+                    timestamp_options,
+                    interface,
+                    x.packet_data,
+                ))
             }
             Block::NameResolution(x) => {
                 info!("Defined a new resolved name: {:?}", x);
@@ -68,7 +98,7 @@ impl Section {
         }
     }
 
-    fn lookup_interface(&self, interface_id: InterfaceId) -> &InterfaceDescription {
+    fn lookup_interface(&self, interface_id: &InterfaceId) -> &InterfaceDescription {
         let interface_id = interface_id.0 as usize;
         assert!(
             interface_id < self.interfaces.len(),
@@ -76,5 +106,15 @@ impl Section {
             interface_id
         );
         &self.interfaces[interface_id]
+    }
+
+    fn lookup_timestamp_options(&self, interface_id: &InterfaceId) -> &TimestampOptions {
+        let interface_id = interface_id.0 as usize;
+        assert!(
+            interface_id < self.interfaces.len(),
+            "Out of bounds: {:?}",
+            interface_id
+        );
+        &self.timestamp_options[interface_id]
     }
 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -20,13 +20,13 @@ impl<'a> Packet<'a> {
 
     pub fn new_enhanced(
         timestamp: u64,
+        timestamp_options: &'a TimestampOptions,
         interface: &'a InterfaceDescription,
         data: &'a [u8],
     ) -> Packet<'a> {
-        // TODO: Get resolution from InterfaceDescription by inspecting if_tsresol
-        let resolution = 1_000_000; // assume microsecond resolution (FIXME)
-        let secs = timestamp / resolution;
-        let nanos = (timestamp * 1_000_000_000 / resolution) as u32;
+        let units_per_sec = timestamp_options.units_per_sec as u64;
+        let secs = timestamp / units_per_sec;
+        let nanos = ((timestamp % units_per_sec) * 1_000_000_000 / units_per_sec) as u32;
         Packet {
             timestamp: Some(Duration::new(secs, nanos)),
             interface: Some(interface),


### PR DESCRIPTION
The parser now understands the if_tsresol option in IDBs and use it to interpret the timestamps in EPBs.
