### PR TITLE
Refuse to parse legacy pcap format instead of failing with a bad error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Refuse to parse legacy pcap format with a clearer error message
+
 ## 2.0.0
 
 * Make `Packet` fully owned (no lifetime parameter)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1.0.39"
 tracing = { version = "0.1.37", features = ["log"] }
 
 [dev-dependencies]
-clap = { version = "4.1.8", features = ["derive"] }
+bpaf = { version = "0.9", features = ["derive"] }
 env_logger = "0.10.0"
 flate2 = "1.0.25"
 humantime = "2.1.0"

--- a/examples/bench.rs
+++ b/examples/bench.rs
@@ -1,4 +1,4 @@
-use std::time::*;
+use std::time::Instant;
 
 fn main() {
     let path = std::path::PathBuf::from(std::env::args().nth(1).unwrap());

--- a/examples/pcap_dump.rs
+++ b/examples/pcap_dump.rs
@@ -1,10 +1,12 @@
 use bpaf::Bpaf;
-use pcarp::*;
-use std::fs::File;
-use std::io::Read;
-use std::path::PathBuf;
-use std::time::*;
-use tracing::*;
+use pcarp::Capture;
+use std::{
+    fs::File,
+    io::Read,
+    path::PathBuf,
+    time::{Instant, SystemTime},
+};
+use tracing::{info, warn};
 
 /// Dumps the packets from a pcapng file
 #[derive(Bpaf)]

--- a/examples/pcap_dump.rs
+++ b/examples/pcap_dump.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use bpaf::Bpaf;
 use pcarp::*;
 use std::fs::File;
 use std::io::Read;
@@ -7,14 +7,16 @@ use std::time::*;
 use tracing::*;
 
 /// Dumps the packets from a pcapng file
-#[derive(Parser)]
+#[derive(Bpaf)]
+#[bpaf(options)]
 struct Opts {
     /// The pcapng file to read from
+    #[bpaf(positional)]
     pcap: PathBuf,
 }
 
 fn main() {
-    let opts = Opts::parse();
+    let opts = opts().fallback_to_usage().run();
 
     env_logger::init();
 

--- a/examples/pcap_dump_libpcap.rs
+++ b/examples/pcap_dump_libpcap.rs
@@ -1,7 +1,10 @@
 use bpaf::Bpaf;
-use pcap::*;
-use std::{path::PathBuf, time::*};
-use tracing::*;
+use pcap::{Capture, Error};
+use std::{
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+use tracing::info;
 
 /// Dumps the packets from a pcapng file
 #[derive(Bpaf)]

--- a/examples/pcap_dump_libpcap.rs
+++ b/examples/pcap_dump_libpcap.rs
@@ -1,17 +1,19 @@
-use clap::Parser;
+use bpaf::Bpaf;
 use pcap::*;
 use std::{path::PathBuf, time::*};
 use tracing::*;
 
 /// Dumps the packets from a pcapng file
-#[derive(Parser)]
+#[derive(Bpaf)]
+#[bpaf(options)]
 struct Opts {
     /// The pcapng file to read from
+    #[bpaf(positional)]
     pcap: PathBuf,
 }
 
 fn main() {
-    let opts = Opts::parse();
+    let opts = opts().fallback_to_usage().run();
 
     env_logger::init();
 

--- a/examples/pcap_rewind.rs
+++ b/examples/pcap_rewind.rs
@@ -1,7 +1,6 @@
 use bpaf::Bpaf;
-use pcarp::*;
-use std::fs::File;
-use std::path::PathBuf;
+use pcarp::Capture;
+use std::{fs::File, path::PathBuf};
 
 /// Example program that demonstrates the rewind support
 #[derive(Bpaf)]

--- a/examples/pcap_rewind.rs
+++ b/examples/pcap_rewind.rs
@@ -1,17 +1,19 @@
-use clap::Parser;
+use bpaf::Bpaf;
 use pcarp::*;
 use std::fs::File;
 use std::path::PathBuf;
 
 /// Example program that demonstrates the rewind support
-#[derive(Parser)]
+#[derive(Bpaf)]
+#[bpaf(options)]
 struct Opts {
     /// The pcapng file to read from
+    #[bpaf(positional)]
     pcap: PathBuf,
 }
 
 fn main() {
-    let opts = Opts::parse();
+    let opts = opts().fallback_to_usage().run();
     env_logger::init();
     let file = File::open(&opts.pcap).unwrap();
     let mut capture = Capture::new(file);

--- a/examples/simple_dump.rs
+++ b/examples/simple_dump.rs
@@ -1,6 +1,8 @@
-use pcap::*;
-use std::fs::File;
-use std::time::*;
+use pcap::{Capture, Error};
+use std::{
+    fs::File,
+    time::{Duration, SystemTime},
+};
 
 fn main() {
     let mut args = std::env::args();

--- a/examples/test_dump.rs
+++ b/examples/test_dump.rs
@@ -1,4 +1,4 @@
-use pcarp::*;
+use pcarp::{Capture, Error, Packet};
 
 fn main() {
     env_logger::init();

--- a/src/block/frame.rs
+++ b/src/block/frame.rs
@@ -41,7 +41,10 @@ pub(crate) fn parse_frame(
             x => return Err(FrameError::DidntUnderstandMagicBytes(x.try_into().unwrap())),
         };
         trace!("Found SHB; setting endianness to {:?}", *endianness);
+    } else if block_type == 0xa1b2c3d4 || block_type == 0xd4c3b2a1 {
+        return Err(FrameError::LegacyPcap);
     }
+
     let block_type = BlockType::from(block_type);
 
     let block_len = read_u32(4, *endianness) as usize;
@@ -70,4 +73,6 @@ pub enum FrameError {
     BlockLengthMismatch(usize, usize),
     #[error("Block's length is {0} bytes, but the minimum length is 12")]
     BlockLengthTooSmall(usize),
+    #[error("Detected legacy pcap format")]
+    LegacyPcap,
 }

--- a/src/block/frame.rs
+++ b/src/block/frame.rs
@@ -1,4 +1,4 @@
-use crate::block::*;
+use crate::block::{trace, BlockType, Endianness};
 use bytes::Buf;
 use thiserror::Error;
 


### PR DESCRIPTION
- **unclap**
- **examples: make it clearer what is imported and where from**
- **Yeet more glob imports**
- **Refuse to parse legacy pcap format**
- **Update changelog**
